### PR TITLE
fix：飞书通知无法触发

### DIFF
--- a/utils/sendNotify.py
+++ b/utils/sendNotify.py
@@ -417,7 +417,7 @@ def send(title, content):
     if QYWX_KEY:
         for i in range(int(len(content) / 2000) + 1):
             wecom_key(title=title, content=content[i * 2000:(i + 1) * 2000])
-    if QYWX_KEY:
+    if FS_KEY:
         fs_key(title=title, content=content)
 
 


### PR DESCRIPTION
bug：
无法启用飞书通知
启用企业微信会意外的触发飞书通知